### PR TITLE
deprecation of Rake::GemPackageTask and added gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "rubygems"
-require "rake/gempackagetask"
-require "rake/rdoctask"
+require "rubygems/package_task"
+require "rdoc/task"
 
 require "spec"
 require "spec/rake/spectask"
@@ -48,7 +48,7 @@ end
 #
 # To publish your gem online, install the 'gemcutter' gem; Read more
 # about that here: http://gemcutter.org/pages/gem_docs
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec
 end
 

--- a/math_engine.gemspec
+++ b/math_engine.gemspec
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name = "math_engine"
+  s.version = "0.5.0"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.authors = ["Michael Baldry"]
+  s.date = "2012-09-03"
+  s.email = "michael.baldry@uswitch.com"
+  s.extra_rdoc_files = ["README.md"]
+  s.files = ["README.md", "spec", "lib/context.rb", "lib/errors.rb", "lib/evaluators", "lib/evaluators/calculate.rb", "lib/evaluators/finders.rb", "lib/lexer.rb", "lib/math_engine.rb", "lib/nodes.rb", "lib/parser.rb"]
+  s.homepage = "http://www.forwardtechnology.co.uk"
+  s.rdoc_options = ["--main", "README.md"]
+  s.require_paths = ["lib"]
+  s.rubygems_version = "1.8.24"
+  s.summary = "Evaluates mathematical expressions"
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 3
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<lexr>, [">= 0.3.0"])
+      s.add_development_dependency(%q<rspec>, [">= 0"])
+    else
+      s.add_dependency(%q<lexr>, [">= 0.3.0"])
+      s.add_dependency(%q<rspec>, [">= 0"])
+    end
+  else
+    s.add_dependency(%q<lexr>, [">= 0.3.0"])
+    s.add_dependency(%q<rspec>, [">= 0"])
+  end
+end


### PR DESCRIPTION
Michael,

Got your email. Not sure how helpful this pull request is to you.
However I prefer that my app pulls from your master over pulling from my fork.
I didn't have an older version of rake handy, so I had to update your Rakefile to overcome the fatal deprecation of Rake::GemPackageTask.
Also while creating the gemspec, I noticed one of the specs fails?

'Evaluating expressions should have the correct value for some simple calculations' FAILED
expected: 70,
     got: (350/5) (using ==)

Correct value, but doesn't seem to perform the final eval?
All other specs passed.
If the error looks familiar and you can direct me, I can attempt to fix it.

Looking forward to using and extending your gem for my purposes.
Thanks for your work. Pretty to read. I always like that!

Bill
